### PR TITLE
Use condas version of python in pyspark

### DIFF
--- a/interpreter.json
+++ b/interpreter.json
@@ -1182,7 +1182,7 @@
         },
         "zeppelin.pyspark.python": {
           "name": "zeppelin.pyspark.python",
-          "value": "python",
+          "value": "/opt/conda/default/bin/python",
           "type": "string"
         },
         "args": {


### PR DESCRIPTION
This PR sets the python path that will be used by the yarn cluster manager (i.e. Dataproc) when executing pyspark from Zeppelin. This is the same path that is used in the hosted dataproc version of Zeppelin.