### PR TITLE
Move notebook auth file to PVC and link from conf dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN ln -sf /etc/hadoop/yarn-site.xml /usr/lib/hadoop/etc/hadoop/yarn-site.xml
 RUN ln -sf /etc/hadoop/core-site.xml /usr/lib/hadoop/etc/hadoop/core-site.xml
 RUN ln -sf /etc/hadoop/hdfs-site.xml /usr/lib/hadoop/etc/hadoop/hdfs-site.xml
 RUN ln -sf /etc/hadoop/mapred-site.xml /usr/lib/hadoop/etc/hadoop/mapred-site.xml
+RUN ln -sf /zeppelin/notebook/notebook-authorization.json /zeppelin/conf/notebook-authorization.json
 
 RUN /root/create-python-env.bash
 

--- a/files/zeppelin/conf/zeppelin-site.xml
+++ b/files/zeppelin/conf/zeppelin-site.xml
@@ -51,7 +51,7 @@
 
 <property>
   <name>zeppelin.notebook.dir</name>
-  <value>notebook</value>
+  <value>notebook/notes</value>
   <description>path or URI for notebook persist</description>
 </property>
 


### PR DESCRIPTION
This should preserve the note permissions between POD restarts and
also remove the exception for "lost+found" in the notebook folder
since I changed the notes folder to a subfolder of the PVC storage.
