### PR TITLE
Add Dockerfile for building a new non-root base image for zeppelin.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
+
+ARG ZEPPELIN_USER_ID=2100
+ARG ZEPPELIN_GROUP_ID=2100
+
+# `Z_VERSION` will be updated by `dev/change_zeppelin_version.sh`
+ENV Z_VERSION="0.8.2"
+ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
+    Z_HOME="/zeppelin" \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+RUN groupadd --gid $ZEPPELIN_GROUP_ID zeppelin \
+    && useradd -ms /bin/bash -d ${Z_HOME} zeppelin --uid $ZEPPELIN_USER_ID --gid $ZEPPELIN_GROUP_ID
+
+RUN echo "$LOG_TAG update and install basic packages" && \
+    apt-get -y update && \
+    apt-get install -y locales && \
+    locale-gen $LANG && \
+    apt-get install -y software-properties-common && \
+    apt -y autoclean && \
+    apt -y dist-upgrade && \
+    apt-get install -y build-essential
+
+RUN echo "$LOG_TAG install tini related packages" && \
+    apt-get install -y wget curl grep sed dpkg && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    dpkg -i tini.deb && \
+    rm tini.deb
+
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN echo "$LOG_TAG Install java8" && \
+    apt-get -y update && \
+    apt-get install -y openjdk-8-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
+# should install conda first before numpy, matploylib since pip and python will be installed by conda
+RUN echo "$LOG_TAG Install miniconda2 related packages" && \
+    apt-get -y update && \
+    apt-get install -y bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion && \
+    echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.2.12-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+ENV PATH /opt/conda/bin:$PATH
+
+RUN echo "$LOG_TAG Install python related packages" && \
+    apt-get -y update && \
+    apt-get install -y python-dev python-pip && \
+    apt-get install -y gfortran && \
+    # numerical/algebra packages
+    apt-get install -y libblas-dev libatlas-dev liblapack-dev && \
+    # font, image for matplotlib
+    apt-get install -y libpng-dev libfreetype6-dev libxft-dev && \
+    # for tkinter
+    apt-get install -y python-tk libxml2-dev libxslt-dev zlib1g-dev && \
+    conda config --set always_yes yes --set changeps1 no && \
+    conda update -q conda && \
+    conda info -a && \
+    conda config --add channels conda-forge && \
+    conda install -q numpy=1.14 pandas=0.21.1 matplotlib=2.1.1 pandasql=0.7.3 ipython=5.4.1 jupyter_client=5.1.0 ipykernel=4.7.0 bokeh=0.12.10 && \
+    pip install --upgrade pip && pip install scipy==1.0 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
+
+RUN echo "$LOG_TAG Install R related packages" && \
+    echo "deb http://cran.rstudio.com/bin/linux/ubuntu xenial/" | tee -a /etc/apt/sources.list && \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key E084DAB9 && \
+    gpg -a --export E084DAB9 | apt-key add - && \
+    apt-get -y update && \
+    apt-get -y --allow-unauthenticated install r-base r-base-dev && \
+    R -e "install.packages('knitr', repos='http://cran.us.r-project.org')" && \
+    R -e "install.packages('ggplot2', repos='http://cran.us.r-project.org')" && \
+    R -e "install.packages('googleVis', repos='http://cran.us.r-project.org')" && \
+    R -e "install.packages('data.table', repos='http://cran.us.r-project.org')" && \
+    # for devtools, Rcpp
+    apt-get -y install libcurl4-gnutls-dev libssl-dev && \
+    R -e "install.packages('devtools', repos='http://cran.us.r-project.org')" && \
+    R -e "install.packages('Rcpp', repos='http://cran.us.r-project.org')" && \
+    Rscript -e "library('devtools'); library('Rcpp'); install_github('ramnathv/rCharts')"
+
+RUN echo "$LOG_TAG Download Zeppelin binary" && \
+    wget -O /tmp/zeppelin-${Z_VERSION}-bin-all.tgz http://archive.apache.org/dist/zeppelin/zeppelin-${Z_VERSION}/zeppelin-${Z_VERSION}-bin-all.tgz && \
+    tar -zxvf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
+    rm -rf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
+    mv /zeppelin-${Z_VERSION}-bin-all/* ${Z_HOME}/ && \
+    chown -R zeppelin:zeppelin ${Z_HOME}/
+
+RUN echo "$LOG_TAG Cleanup" && \
+    apt-get autoclean && \
+    apt-get clean
+
+USER zeppelin
+
+EXPOSE 8080
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+WORKDIR ${Z_HOME}
+CMD ["bin/zeppelin.sh"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Dockerfile for building Zeppelin
 
-This repository contains a Dockerfile, script and configuration for building a custom Zeppelin image.
+This repository contains a Dockerfile, script and configuration for building a
+custom Zeppelin image.
 
 ## Zeppelin
 
-Docker image is based on `docker.io/apache/zeppelin:0.8.2`.
+Current docker image is based on `docker.io/apache/zeppelin:0.8.2`. In case
+switching to a non-root image, base image should be switched to
+`eu.gcr.io/prod-bip/ssb/zeppelin:0.8.2-nonroot` which is in turn based on
+`docker.io/apache/zeppelin:0.8.2` with additions related to the change of
+folders/processes ownership. Exact Docekerfile used to build a new `nonroot`
+base image is placed in the root of the current repository, see
+`Dockerfile.base`
 
 ### Building
 


### PR DESCRIPTION
PR contains Dockerfile for a new non-root docker image.

Current version of the new non-root base image is built locally and push to:  `eu.gcr.io/prod-bip/ssb/zeppelin:0.8.2-nonroot`.

**Important**

Using new image in `ssb-chart`, requires additional helm release configuration.