### PR TITLE
Use non-root base image for building custom zeppelin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM apache/zeppelin:0.8.2
+FROM eu.gcr.io/prod-bip/ssb/zeppelin:0.8.2-nonroot
+
+USER root
 
 WORKDIR /
 
@@ -30,6 +32,9 @@ ENV DAPLA_SPARK_ACCESS_URL=https://data-access.staging-bip-app.ssb.no
 
 RUN wget -P /tmp https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
 RUN mv /tmp/gcs-connector-hadoop2-latest.jar /zeppelin/lib/gcs-connector-hadoop.jar
+RUN chown -R zeppelin:zeppelin /zeppelin
+
+USER zeppelin
 
 WORKDIR /zeppelin
 CMD ["/root/env.sh"]


### PR DESCRIPTION
Use non-root base image (built from Dockerfile.base file) for building custom zeppelin.

**NB**

Don't merge before making modification to zeppelin HelmRelease in platform-dev repository (owner field must be setup for zeppelin user).